### PR TITLE
ci: prevent build when opening pr

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,6 @@ name: TDP Website Publish
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 jobs:
   www:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Prevent deploying on gh pages when a PR is opened.