### PR TITLE
chore(project): use npx with husky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname $0)/_/husky.sh"
 
-yarn commitlint --edit $1
+npx commitlint --edit $1


### PR DESCRIPTION
YARN should not be required. With this commit, Husky uses npx which shall be available on all recent npm install