### PR TITLE
chore(project): nextjs downgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "glob": "^10.2.7",
         "mdx-annotations": "^0.1.3",
         "mixme": "^0.5.9",
-        "next": "^13.5.2",
+        "next": "13.4.16",
         "next-mdx-remote": "^4.4.1",
         "postcss": "^8.4.24",
         "react": "^18.2.0",
@@ -2547,9 +2547,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.3.tgz",
-      "integrity": "sha512-X4te86vsbjsB7iO4usY9jLPtZ827Mbx+WcwNBGUOIuswuTAKQtzsuoxc/6KLxCMvogKG795MhrR1LDhYgDvasg=="
+      "version": "13.4.16",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.16.tgz",
+      "integrity": "sha512-pCU0sJBqdfKP9mwDadxvZd+eLz3fZrTlmmDHY12Hdpl3DD0vy8ou5HWKVfG0zZS6tqhL4wnQqRbspdY5nqa7MA=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.5.3",
@@ -2599,9 +2599,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.3.tgz",
-      "integrity": "sha512-6hiYNJxJmyYvvKGrVThzo4nTcqvqUTA/JvKim7Auaj33NexDqSNwN5YrrQu+QhZJCIpv2tULSHt+lf+rUflLSw==",
+      "version": "13.4.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.16.tgz",
+      "integrity": "sha512-Rl6i1uUq0ciRa3VfEpw6GnWAJTSKo9oM2OrkGXPsm7rMxdd2FR5NkKc0C9xzFCI4+QtmBviWBdF2m3ur3Nqstw==",
       "cpu": [
         "arm64"
       ],
@@ -2614,9 +2614,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.3.tgz",
-      "integrity": "sha512-UpBKxu2ob9scbpJyEq/xPgpdrgBgN3aLYlxyGqlYX5/KnwpJpFuIHU2lx8upQQ7L+MEmz+fA1XSgesoK92ppwQ==",
+      "version": "13.4.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.16.tgz",
+      "integrity": "sha512-o1vIKYbZORyDmTrPV1hApt9NLyWrS5vr2p5hhLGpOnkBY1cz6DAXjv8Lgan8t6X87+83F0EUDlu7klN8ieZ06A==",
       "cpu": [
         "x64"
       ],
@@ -2629,9 +2629,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.3.tgz",
-      "integrity": "sha512-5AzM7Yx1Ky+oLY6pHs7tjONTF22JirDPd5Jw/3/NazJ73uGB05NqhGhB4SbeCchg7SlVYVBeRMrMSZwJwq/xoA==",
+      "version": "13.4.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.16.tgz",
+      "integrity": "sha512-JRyAl8lCfyTng4zoOmE6hNI2f1MFUr7JyTYCHl1RxX42H4a5LMwJhDVQ7a9tmDZ/yj+0hpBn+Aan+d6lA3v0UQ==",
       "cpu": [
         "arm64"
       ],
@@ -2644,9 +2644,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.3.tgz",
-      "integrity": "sha512-A/C1shbyUhj7wRtokmn73eBksjTM7fFQoY2v/0rTM5wehpkjQRLOXI8WJsag2uLhnZ4ii5OzR1rFPwoD9cvOgA==",
+      "version": "13.4.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.16.tgz",
+      "integrity": "sha512-9gqVqNzUMWbUDgDiND18xoUqhwSm2gmksqXgCU0qaOKt6oAjWz8cWYjgpPVD0WICKFylEY/gvPEP1fMZDVFZ/g==",
       "cpu": [
         "arm64"
       ],
@@ -2659,9 +2659,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.3.tgz",
-      "integrity": "sha512-FubPuw/Boz8tKkk+5eOuDHOpk36F80rbgxlx4+xty/U71e3wZZxVYHfZXmf0IRToBn1Crb8WvLM9OYj/Ur815g==",
+      "version": "13.4.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.16.tgz",
+      "integrity": "sha512-KcQGwchAKmZVPa8i5PLTxvTs1/rcFnSltfpTm803Tr/BtBV3AxCkHLfhtoyVtVzx/kl/oue8oS+DSmbepQKwhw==",
       "cpu": [
         "x64"
       ],
@@ -2674,9 +2674,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.3.tgz",
-      "integrity": "sha512-DPw8nFuM1uEpbX47tM3wiXIR0Qa+atSzs9Q3peY1urkhofx44o7E1svnq+a5Q0r8lAcssLrwiM+OyJJgV/oj7g==",
+      "version": "13.4.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.16.tgz",
+      "integrity": "sha512-2RbMZNxYnJmW8EPHVBsGZPq5zqWAyBOc/YFxq/jIQ/Yn3RMFZ1dZVCjtIcsiaKmgh7mjA/W0ApbumutHNxRqqQ==",
       "cpu": [
         "x64"
       ],
@@ -2689,9 +2689,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.3.tgz",
-      "integrity": "sha512-zBPSP8cHL51Gub/YV8UUePW7AVGukp2D8JU93IHbVDu2qmhFAn9LWXiOOLKplZQKxnIPUkJTQAJDCWBWU4UWUA==",
+      "version": "13.4.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.16.tgz",
+      "integrity": "sha512-thDcGonELN7edUKzjzlHrdoKkm7y8IAdItQpRvvMxNUXa4d9r0ElofhTZj5emR7AiXft17hpen+QAkcWpqG7Jg==",
       "cpu": [
         "arm64"
       ],
@@ -2704,9 +2704,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.3.tgz",
-      "integrity": "sha512-ONcL/lYyGUj4W37D4I2I450SZtSenmFAvapkJQNIJhrPMhzDU/AdfLkW98NvH1D2+7FXwe7yclf3+B7v28uzBQ==",
+      "version": "13.4.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.16.tgz",
+      "integrity": "sha512-f7SE1Mo4JAchUWl0LQsbtySR9xCa+x55C0taetjUApKtcLR3AgAjASrrP+oE1inmLmw573qRnE1eZN8YJfEBQw==",
       "cpu": [
         "ia32"
       ],
@@ -2719,9 +2719,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.3.tgz",
-      "integrity": "sha512-2Vz2tYWaLqJvLcWbbTlJ5k9AN6JD7a5CN2pAeIzpbecK8ZF/yobA39cXtv6e+Z8c5UJuVOmaTldEAIxvsIux/Q==",
+      "version": "13.4.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.16.tgz",
+      "integrity": "sha512-WamDZm1M/OEM4QLce3lOmD1XdLEl37zYZwlmOLhmF7qYJ2G6oYm9+ejZVv+LakQIsIuXhSpVlOvrxIAHqwRkPQ==",
       "cpu": [
         "x64"
       ],
@@ -3074,9 +3074,9 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
-      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -8771,12 +8771,12 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.5.3.tgz",
-      "integrity": "sha512-4Nt4HRLYDW/yRpJ/QR2t1v63UOMS55A38dnWv3UDOWGezuY0ZyFO1ABNbD7mulVzs9qVhgy2+ppjdsANpKP1mg==",
+      "version": "13.4.16",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.16.tgz",
+      "integrity": "sha512-1xaA/5DrfpPu0eV31Iro7JfPeqO8uxQWb1zYNTe+KDKdzqkAGapLcDYHMLNKXKB7lHjZ7LfKUOf9dyuzcibrhA==",
       "dependencies": {
-        "@next/env": "13.5.3",
-        "@swc/helpers": "0.5.2",
+        "@next/env": "13.4.16",
+        "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -8788,18 +8788,18 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=16.14.0"
+        "node": ">=16.8.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.5.3",
-        "@next/swc-darwin-x64": "13.5.3",
-        "@next/swc-linux-arm64-gnu": "13.5.3",
-        "@next/swc-linux-arm64-musl": "13.5.3",
-        "@next/swc-linux-x64-gnu": "13.5.3",
-        "@next/swc-linux-x64-musl": "13.5.3",
-        "@next/swc-win32-arm64-msvc": "13.5.3",
-        "@next/swc-win32-ia32-msvc": "13.5.3",
-        "@next/swc-win32-x64-msvc": "13.5.3"
+        "@next/swc-darwin-arm64": "13.4.16",
+        "@next/swc-darwin-x64": "13.4.16",
+        "@next/swc-linux-arm64-gnu": "13.4.16",
+        "@next/swc-linux-arm64-musl": "13.4.16",
+        "@next/swc-linux-x64-gnu": "13.4.16",
+        "@next/swc-linux-x64-musl": "13.4.16",
+        "@next/swc-win32-arm64-msvc": "13.4.16",
+        "@next/swc-win32-ia32-msvc": "13.4.16",
+        "@next/swc-win32-x64-msvc": "13.4.16"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "glob": "^10.2.7",
     "mdx-annotations": "^0.1.3",
     "mixme": "^0.5.9",
-    "next": "^13.5.2",
+    "next": "13.4.16",
     "next-mdx-remote": "^4.4.1",
     "postcss": "^8.4.24",
     "react": "^18.2.0",


### PR DESCRIPTION
The latest version of Next, currently 13.5.3, compiles succcessfull but generate many issue in a dev environment. Among them, components injected into `next-mdx-remote/rsc` are no longer working when declared as client components. This is the case for the majority of them including the `Code` and `Tabs` components.

The official `next-mdx-remote` doc mentions: "Custom components can no longer be provided by using the MDXProvider context from @mdx-js/react, as RSC does not support React Context". I am not sure about the usage `MDXProvider` is used but we certainly use React Context in those components. At the same time, React Context and client components worked like a charm until Next version `13.4.16`.

I propose to freeze the next version for some time until Next app stabilizes.