### PR TITLE
Report creation script

### DIFF
--- a/bin/reportInit.mjs
+++ b/bin/reportInit.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+/**
+ * This script automates the generation of meeting reports for TOSIT-IO's open pull requests.
+ * It fetches pull request data from GitHub, formats it, and creates a Markdown report file in a new branch.
+ */
+
+import fs from 'node:fs/promises'
+import { fileURLToPath } from 'url'
+import { exec as execCallback } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const exec = promisify(execCallback)
+
+const reportsDirectory = 'content/reports'
+const reportType = 'contributors'
+const pullsURL =
+  'https://api.github.com/search/issues?q=is:pr+user:TOSIT-IO+is:open+sort:created-asc'
+
+const formatCurrentDate = (date) =>
+  new Date(date)
+    .toLocaleString('fr', { year: '2-digit', month: '2-digit', day: '2-digit' })
+    .split('/')
+    .reverse()
+    .join('')
+
+async function checkoutNewBranch(branchName) {
+  try {
+    const currentBranch = (
+      await exec('git branch --show-current')
+    ).stdout.trim()
+    if (currentBranch !== branchName) {
+      try {
+        await exec(`git checkout ${branchName}`)
+      } catch (error) {
+        if (error.stderr.includes('did not match any file(s) known to git')) {
+          await exec(`git checkout -b ${branchName}`)
+        } else {
+          throw error
+        }
+      }
+    }
+  } catch (error) {
+    console.error('Failed to checkout new branch:')
+    console.error(error.stderr)
+  }
+}
+
+async function fetchPulls() {
+  try {
+    const pulls = await fetch(pullsURL)
+    return pulls.json()
+  } catch (error) {
+    console.error('Failed to fetch pulls:', error)
+    return []
+  }
+}
+
+function formatPulls(pulls) {
+  if (!pulls || pulls.total_count === 0) {
+    return ''
+  }
+  return pulls
+    .map((pull) => {
+      const { number, title, html_url: url } = pull
+      const repo = pull.repository_url.split('/').pop()
+      return `- [${repo}#${number}](${url}): <!-- status of "${title}" -->`
+    })
+    .join('\n')
+}
+
+function generateReportContent(pullsDetails, currentDate, reportType) {
+  return `---
+type: ${reportType}
+date: ${currentDate.toISOString().split('T')[0]}
+description: |
+<main topics of the meeting>
+---
+
+# TDP ${reportType} meeting notes
+
+<!-- general notes -->
+
+## Pull Requests
+
+Weekly review of open PRs (in chronological order):
+
+${pullsDetails}
+
+## Open topics
+
+<!-- open topics -->
+`
+}
+
+try {
+  const rootDirURL = new URL('..', import.meta.url)
+  const repoPath = fileURLToPath(rootDirURL)
+  const currentDate = new Date()
+  const dateStr = formatCurrentDate(currentDate)
+  // Change directory to the root of the repo
+  try {
+    process.chdir(repoPath)
+  } catch (error) {
+    console.error('Failed to change directory:', error)
+  }
+  // Checkout a new branch for the report
+  await checkoutNewBranch(`${dateStr}-${reportType}-report`)
+  // Fetch and format the pull requests
+  const pulls = await fetchPulls()
+  if (!pulls || pulls.total_count === 0) {
+    console.log('No pull requests to report')
+  }
+  const pullsDetails = formatPulls(pulls.items)
+  // Generate and write the report
+  const reportContent = generateReportContent(
+    pullsDetails,
+    currentDate,
+    reportType
+  )
+  const reportBaseName = `${dateStr}-${reportType}.md`
+  const reportBaseDirURL = new URL(reportsDirectory, rootDirURL)
+  const reportBaseDirPath = fileURLToPath(reportBaseDirURL)
+  const reportPath = `${reportBaseDirPath}/${reportBaseName}`
+  try {
+    await fs.writeFile(reportPath, reportContent)
+    console.log(
+      `${reportsDirectory}/${reportBaseName} has been created with ${pulls.total_count} pending PRs`
+    )
+  } catch (error) {
+    console.error('Failed to write report:', error)
+  }
+} catch (error) {
+  console.error('Unexpected error:', error)
+}

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "postinstall": "husky install",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
+    "reportinit": "node bin/reportInit.mjs",
     "start": "serve out",
     "test": "npx mocha 'src/test/**/*.js'"
   },


### PR DESCRIPTION
Provide a script to easily create new meeting notes reports.

## Usage

```sh
npm run reportinit
```

## Result

Create a `yymmdd-contributors.md` file on a new `yymmdd-contributors-report` branch containing a template populated with the pending PRs. For example:

```md
---
type: contributors
date: 2023-10-28
description: |
<main topics of the meeting>
---

# TDP contributors meeting notes

<!-- general notes -->

## Pull Requests

Weekly review of open PRs (in chronological order):

- [tdp-ui#198](https://github.com/TOSIT-IO/tdp-ui/pull/198): <!-- status of "Release automation" -->
- [tdp-collection#745](https://github.com/TOSIT-IO/tdp-collection/pull/745): <!-- status of "WIP: 612 yarn timeline v2" -->
- [tdp-ui#210](https://github.com/TOSIT-IO/tdp-ui/pull/210): <!-- status of "chore: add dev environment without auth" -->

## Open topics

<!-- open topics -->

```