### PR TITLE
fix(project): add ini language in highlighter

### DIFF
--- a/src/mdx/rehype-highlighter.js
+++ b/src/mdx/rehype-highlighter.js
@@ -19,6 +19,7 @@ export default function rehypeShiki() {
         ],
         langs: [
           'go',
+          'ini',
           'javascript',
           'js',
           'json',


### PR DESCRIPTION
Added the `ini` language in the file `src/mdx/rehype-highlighter.js` which is required.