### PR TITLE
Use NPM for publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,8 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: yarn install --frozen-lockfile
-    - run: yarn run build
+    - run: npm ci
+    - run: npm run build
     # By default, GH pages support jekyll
     # and ignore underscore paths such as `_next`
     - run: touch out/.nojekyll

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,5 +17,5 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: yarn install --frozen-lockfile
-    - run: yarn run build
+    - run: npm ci
+    - run: npm run build


### PR DESCRIPTION
Use NPM instead of Yarn in the GitHub actions to make use of the `package-lock.json`.