### PR TITLE
feat(pages): added tdp-extra and tdp-observability components in table for stack 1.1

### DIFF
--- a/src/mdx/components/stacks/data.ts
+++ b/src/mdx/components/stacks/data.ts
@@ -338,12 +338,198 @@ const stacks: { [k in StackNames]: Stack } = {
     extras: {
       repositoryUrl: 'https://github.com/TOSIT-IO/tdp-collection-extras',
       tag: '1.0.0',
-      components: [],
+      components: [
+        {
+          name: 'Apache Zookeeper',
+          upstream: {
+            label: 'Apache',
+            version: '3.5.9',
+            repositoryUrl: 'https://github.com/apache/zookeeper/releases',
+            tag: 'release-3.5.9',
+            binaryUrl:
+              'https://archive.apache.org/dist/zookeeper/zookeeper-3.5.9/apache-zookeeper-3.5.9-bin.tar.gz',
+          },
+        },
+        {
+          name: 'Apache Kafka',
+          upstream: {
+            label: 'Apache',
+            version: '2.8.2',
+            repositoryUrl: 'https://github.com/apache/kafka',
+            tag: '2.8.2',
+          },
+          tosit: {
+            repositoryUrl: 'https://github.com/TOSIT-IO/kafka',
+            releases: {
+              basic: {
+                tag: '2.8.2-TDP-0.1.0',
+                binaryUrl:
+                  'https://github.com/TOSIT-IO/kafka/releases/download/2.8.2-TDP-0.1.0/kafka_2.13-2.8.2-TDP-0.1.0-SNAPSHOT.tgz',
+              },
+            },
+          },
+        },
+        {
+          name: 'Apache Livy',
+          upstream: {
+            label: 'Apache',
+            version: '0.8.0-incubating',
+            repositoryUrl: 'https://github.com/apache/incubator-livy',
+            tag: 'v0.8.0-incubating-rc1',
+          },
+          tosit: {
+            repositoryUrl: 'https://github.com/TOSIT-IO/incubator-livy',
+            releases: {
+              fix: {
+                tag: '0.8.0-incubating-1.0',
+                binaryUrl: [
+                  'https://github.com/TOSIT-IO/incubator-livy/releases/download/0.8.0-incubating-1.0/apache-livy-0.8.0-incubating-1.0_2.12-bin.zip',
+                  'https://github.com/TOSIT-IO/incubator-livy/releases/download/0.8.0-incubating-1.0/apache-livy-0.8.0-incubating-1.0_2.12-bin-thrift.zip',
+                ],
+              },
+            },
+          },
+        },
+        {
+          name: 'Cloudera Hue',
+          upstream: {
+            label: 'Cloudera',
+            version: '4.11.0',
+            repositoryUrl: 'https://github.com/cloudera/hue',
+            tag: 'release-4.11.0',
+          },
+          tosit: {
+            repositoryUrl: 'https://github.com/TOSIT-IO/hue',
+            releases: {
+              fix: {
+                tag: 'hue-release-4.11.0-1.0-cp38-cp38-manylinux2014_x86_64',
+                binaryUrl:
+                  'https://github.com/TOSIT-IO/hue/releases/download/hue-release-4.11.0-1.0-cp38-cp38-manylinux2014_x86_64/hue-release-4.11.0-1.0-cp38-cp38-manylinux2014_x86_64.tar.gz',
+              },
+            },
+          },
+        },
+        {
+          name: 'JupyterHub',
+          upstream: {
+            label: 'JupyterHub',
+            version: '2.3.1',
+            repositoryUrl: 'https://github.com/jupyterhub/jupyterhub',
+            tag: '2.3.1',
+          },
+          tosit: {
+            repositoryUrl: 'https://github.com/TOSIT-IO/jupyterhub',
+            releases: {
+              basic: {
+                tag: '2.3.1-0.0',
+                binaryUrl:
+                  'https://github.com/TOSIT-IO/jupyterhub/releases/download/2.3.1-0.0/jupyterhub-2.3.1-0.0.tar.gz',
+              },
+            },
+          },
+        },
+        {
+          name: 'JupyterLab',
+          upstream: {
+            label: 'JupyterLab',
+            version: '3.2.9',
+            repositoryUrl: 'https://github.com/jupyterlab/jupyterlab',
+            tag: 'v3.2.9',
+          },
+          tosit: {
+            repositoryUrl: 'https://github.com/TOSIT-IO/jupyterlab',
+            releases: {
+              basic: {
+                tag: '3.2.9-0.0',
+                binaryUrl:
+                  'https://github.com/TOSIT-IO/jupyterlab/releases/download/3.2.9-0.0/jupyterlab-3.2.9-0.0.tar.gz',
+              },
+            },
+          },
+        },
+        {
+          name: 'Sparkmagic',
+          upstream: {
+            label: 'jupyter-incubator',
+            version: '0.21.0',
+            repositoryUrl: 'https://github.com/jupyter-incubator/sparkmagic',
+            tag: '0.21.0',
+          },
+          tosit: {
+            repositoryUrl: 'https://github.com/TOSIT-IO/sparkmagic',
+            releases: {
+              basic: {
+                tag: '0.21.0-0.0',
+                binaryUrl:
+                  'https://github.com/TOSIT-IO/sparkmagic/releases/download/0.21.0-0.0/sparkmagic-0.21.0-0.0.tar.gz',
+              },
+            },
+          },
+        },
+      ],
     },
     observability: {
       repositoryUrl: 'https://github.com/TOSIT-IO/tdp-observability',
       tag: '1.0.1',
-      components: [],
+      components: [
+        {
+          name: 'Node Exporter',
+          upstream: {
+            label: 'Prometheus',
+            version: '1.3.1',
+            repositoryUrl: 'https://github.com/prometheus/node_exporter',
+            tag: 'v1.3.1',
+            binaryUrl:
+              'https://github.com/prometheus/node_exporter/releases/download/v1.3.1/node_exporter-1.3.1.linux-amd64.tar.gz',
+          },
+        },
+        {
+          name: 'Grafana',
+          upstream: {
+            label: 'Grafana',
+            version: '10.4.1',
+            repositoryUrl: 'https://github.com/grafana/grafana',
+            tag: 'v10.4.1',
+            binaryUrl:
+              'https://dl.grafana.com/oss/release/grafana-10.4.1.linux-amd64.tar.gz',
+          },
+        },
+        {
+          name: 'Loki',
+          upstream: {
+            label: 'Grafana Loki',
+            version: '2.7.2',
+            repositoryUrl: 'https://github.com/grafana/loki',
+            tag: 'v2.7.2',
+            binaryUrl: [
+              'https://github.com/grafana/loki/releases/download/v2.7.2/promtail-linux-amd64.zip',
+              'https://github.com/grafana/loki/releases/download/v2.7.2/loki-linux-amd64.zip',
+            ],
+          },
+        },
+        {
+          name: 'Prometheus',
+          upstream: {
+            label: 'Prometheus',
+            version: '2.37.6',
+            repositoryUrl: 'https://github.com/prometheus/prometheus',
+            tag: 'v2.37.6',
+            binaryUrl:
+              'https://github.com/prometheus/prometheus/releases/download/v2.37.6/prometheus-2.37.6.linux-amd64.tar.gz',
+          },
+        },
+        {
+          name: 'Alertmanager',
+          upstream: {
+            label: 'Prometheus',
+            version: '0.26.0',
+            repositoryUrl: 'https://github.com/prometheus/prometheus',
+            tag: 'v0.26.0',
+            binaryUrl:
+              'https://github.com/prometheus/alertmanager/releases/download/v0.26.0/alertmanager-0.26.0.linux-amd64.tar.gz',
+          },
+        },
+      ],
     },
   },
   'tdp-2.0': {


### PR DESCRIPTION
TDP extra and TDP observability components were still missing on [tdp-website](https://www.trunkdataplatform.io/en/discover/stacks/tdp1-1).