### PR TITLE
refactor(pages): update build order in Build and release page and fix typo

### DIFF
--- a/content/pages/3.contribute/2.build/1.build-release.md
+++ b/content/pages/3.contribute/2.build/1.build-release.md
@@ -12,18 +12,22 @@ Kubernetes pods scheduling allows for **truly** reproducible and isolated builds
 
 ### Build order
 
-- hadoop
-- tez
-- hive1
-- spark
-- hive2
-- spark3
-- hive
-- hbase
-- ranger
-- phoenix
-- phoenix-queryserver
-- knox
+- Zookeeper (for TDP stack 2 only)
+- Hadoop
+- Tez
+- Hive1 (for TDP stack 1.1 only)
+- Spark (for TDP stack 1.1 only)
+- Hive2 (for TDP stack 1.1 only)
+- Spark3
+- Hive
+- HBase
+- Ranger
+- Phoenix
+- Phoenix-queryserver
+- Knox
+- HBase Connectors (for TDP stack 1.1 only)
+- HBase Operator tools
+- Iceberg (for TDP stack 2 only)
 
 ### Kubernetes
 

--- a/content/pages/3.contribute/2.build/2.versioning.md
+++ b/content/pages/3.contribute/2.build/2.versioning.md
@@ -5,7 +5,7 @@ nav_title: Software versioning
 ---
 
 # Software versioning sofware in the TDP Project
- 
+
 This document provides guidelines for versioning and releasing software for the TDP Project.
 
 As of April 2023, the TDP project includes:


### PR DESCRIPTION
Update build order in order to take both stacks TDP 1.1 and TDP 2 into account.